### PR TITLE
chore: update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ started by calling the `local_node.sh` script from the Evmos main repository.
 
 ## Installation
 
+In order to install the tool, clone the source and install locally.
+Note, that using `go install github.com/MalteHerrmann/upgrade-local-node-go@latest`
+does not work because of the replace directives in `go.mod`,
+which are necessary for the Evmos dependencies.
+
 ```bash
-go install github.com/MalteHerrmann/upgrade-local-node-go@latest
+git clone https://github.com/MalteHerrmann/upgrade-local-node-go.git
+cd upgrade-local-node-go
+make install
 ```
 
 ## Features

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/MalteHerrmann/upgrade-local-node-go
 go 1.21
 
 require (
-	github.com/cometbft/cometbft v0.37.2
 	github.com/cosmos/cosmos-sdk v0.47.4
 	github.com/evmos/evmos/v14 v14.0.0-rc3
 	github.com/pkg/errors v0.9.1
@@ -43,6 +42,7 @@ require (
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0 // indirect
+	github.com/cometbft/cometbft v0.37.2 // indirect
 	github.com/cometbft/cometbft-db v0.8.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect


### PR DESCRIPTION
Since using the concrete type implementations from Evmos and the Cosmos-SDK it is not possible to install the tool using `go install github.com/MalteHerrmann/upgrade-local-node-go@latest` anymore.

This is because of the `replace` directives necessary for Evmos (replace SDK and Geth). For more info on this, check [golang/go#40276](https://github.com/golang/go/issues/40276) and specifically the section on replace directives.