### PR TITLE
imp(all): Use golangci-lint v2 and add option for fee amounts in CLI commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
-name: Linters
+name: Lint codebase
 on:
+  push:
+    branches:
+      - main
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   golangci:
@@ -10,10 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-          cache: false
+          go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          # Require: The version of golangci-lint to use.
-          version: latest
+          version: v2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,16 @@
-run:
-  tests: true
-  timeout: 5m
-  concurrency: 4
-  modules-download-mode: readonly
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    # unwanted linters
-    - depguard # would have loved to add but doesn't seem to work correctly
+    - depguard
     - err113
-    - exhaustruct
+    - exhaustruct # requires every field to be instantiated in e.g. struct creation
     - gochecknoglobals
-    - gochecknoinits
-    - gomnd
     - gomoddirectives
     - mnd
-
-linters-settings:
-  dogsled:
-    max-blank-identifiers: 1
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false
-    require-explanation: true
-    require-specific: true
-  varnamelen:
-    ignore-names:
-      - tc
+    - varnamelen
+formatters:
+  enable:
+    - gofumpt
+run:
+  go: "1.23"

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ install:
 
 # ----------------------------------
 # Linting
+LINT_IMAGE=golangci/golangci-lint:v2.1.6
 lint:
 	@echo "Running golangci-lint..." && \
-	golangci-lint run && \
-	echo " > Done."
+	docker run -t --rm -v $(CURDIR):/app -w /app $(LINT_IMAGE) golangci-lint run
 
 # ----------------------------------
 # Tests

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,5 @@
+// Package cmd contains the required logic to run the individual subcommands
+// for the evmos-utils.
 package cmd
 
 import (
@@ -25,6 +27,8 @@ It can be used to test upgrades, deposit or vote for specific or the latest prop
 	chainID string
 	// denom of the chain's fee token.
 	denom string
+	// feeAmount is the amount of fees to send with a default transaction.
+	feeAmount int
 	// home is the home directory of the binary.
 	home string
 	// keyringBackend is the keyring to use.
@@ -71,6 +75,12 @@ func init() {
 		"http://localhost:26657",
 		"Node to post queries and transactions to",
 	)
+	rootCmd.PersistentFlags().IntVar(
+		&feeAmount,
+		"fees",
+		utils.GetDefaultFees(),
+		"Amount of fees to send with a default transaction",
+	)
 
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(depositCmd)
@@ -84,6 +94,7 @@ func collectConfig() utils.BinaryConfig {
 		Appd:           appd,
 		ChainID:        chainID,
 		Denom:          denom,
+		FeeAmount:      feeAmount,
 		Home:           home,
 		KeyringBackend: keyringBackend,
 		Node:           node,

--- a/gov/deposit.go
+++ b/gov/deposit.go
@@ -1,3 +1,5 @@
+// Package gov contains all logic related to governance queries and transactions
+// like voting and checking minimum deposits, etc.
 package gov
 
 import (
@@ -61,8 +63,8 @@ func GetMinDeposit(bin *utils.Binary) (sdk.Coins, error) {
 // ParseMinDepositFromResponse parses the minimum deposit from the given output of the governance
 // parameters query.
 //
-// FIXME: It wasn't possible to unmarshal the JSON output of the query because of a missing unit in the max_deposit_period
-// parameter. This should rather be done using GRPC.
+// NOTE: It wasn't possible to unmarshal the JSON output of the query because of a missing unit in the
+// max_deposit_period parameter. This could instead be done using GRPC.
 func ParseMinDepositFromResponse(out string) (sdk.Coins, error) {
 	depositPatternRaw := `min_deposit":\[{"denom":"(\w+)","amount":"(\d+)`
 	depositPattern := regexp.MustCompile(depositPatternRaw)

--- a/gov/proposal.go
+++ b/gov/proposal.go
@@ -73,6 +73,7 @@ func QueryLatestProposalID(bin *utils.Binary) (int, error) {
 		return 0, errors.New("no proposals found")
 	}
 
+	//#nosec G115 // proposal id won't exceed int32
 	return int(res.Proposals[len(res.Proposals)-1].Id), nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Package main orchestrates the execution of the evmos-utils.
 package main
 
 import (

--- a/utils/binary.go
+++ b/utils/binary.go
@@ -1,3 +1,5 @@
+// Package utils contains different helper types and functions
+// to make handling of the gRPC responses easier and handle different binaries, etc..
 package utils
 
 import (
@@ -38,6 +40,8 @@ type BinaryConfig struct {
 	ChainID string
 	// Denom for the fee payments on transactions
 	Denom string
+	// FeeAmount is the amount of fees send with a default transaction.
+	FeeAmount int
 	// Home is the home directory of the binary.
 	Home string
 	// KeyringBackend defines which keyring to use

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -6,3 +6,8 @@ const (
 	// DeltaHeight is the amount of blocks in the future that the upgrade will be scheduled.
 	DeltaHeight = 20
 )
+
+// GetDefaultFees returns the value for the default amount of fees being sent with transactions.
+func GetDefaultFees() int {
+	return defaultFees
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,7 +18,7 @@ type QueryArgs struct {
 	Quiet      bool
 }
 
-// ExecuteQueryCmd executes a query command.
+// ExecuteQuery executes a query command against a given binary.
 func ExecuteQuery(bin *Binary, args QueryArgs) (string, error) {
 	queryCommand := args.Subcommand
 	queryCommand = append(queryCommand, "--node", bin.Config.Node)
@@ -45,11 +45,13 @@ func ExecuteTx(bin *Binary, args TxArgs) (string, error) {
 		"--from", args.From,
 		"--keyring-backend", bin.Config.KeyringBackend,
 		"--gas", "auto",
-		"--fees", fmt.Sprintf("%d%s", defaultFees, bin.Config.Denom),
+		"--fees", fmt.Sprintf("%d%s", bin.Config.FeeAmount, bin.Config.Denom),
 		"--gas-adjustment", "1.3",
 		"-b", "sync",
 		"-y",
 	)
+
+	bin.Logger.Info().Msgf("executing transaction with command: %s", strings.Join(txCommand, " "))
 
 	return ExecuteBinaryCmd(bin, BinaryCmdArgs{
 		Subcommand: txCommand,


### PR DESCRIPTION
This PR bumps the used version plus config of `golangci-lint` to v2.1.6.

Additionally, it's now possible to set `--fees 10038` to pass an exact fee amount of the given `--denom` to pass along with a transaction.